### PR TITLE
Create Github Action to release winget package

### DIFF
--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -8,8 +8,6 @@ on:
         description: "Specific tag name"
         required: false
         type: string
-env:
-  CI: true
 jobs:
   winget-publish:
     name: Publish winget package
@@ -27,4 +25,4 @@ jobs:
           version: ${{ env.WINGET_TAG_NAME }}
           release-tag: ${{ inputs.tag_name || github.event.release.tag_name }}
           token: ${{ secrets.WINGET_ACC_TOKEN }}
-          # fork-user: triplex-bot
+          fork-user: triplex-bot

--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       tag_name:
         description: "Specific tag name"
-        required: false
+        required: true
         type: string
 jobs:
   winget-publish:

--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -1,0 +1,30 @@
+name: Submit Winget Package to Windows Package Manager Community Repository
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Specific tag name"
+        required: false
+        type: string
+env:
+  CI: true
+jobs:
+  winget-publish:
+    name: Publish winget package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set winget version env
+        env:
+          TAG_NAME: ${{ inputs.tag_name || github.event.release.tag_name }}
+        run: echo "WINGET_TAG_NAME=$(echo ${TAG_NAME#v})" >> $GITHUB_ENV
+      - name: Submit package to Windows Package Manager Community Repository
+        uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: Triplex.Triplex
+          installers-regex: '^Triplex-Setup-[\d\.]+\.exe$'
+          version: ${{ env.WINGET_TAG_NAME }}
+          release-tag: ${{ inputs.tag_name || github.event.release.tag_name }}
+          token: ${{ secrets.WINGET_ACC_TOKEN }}
+          # fork-user: triplex-bot


### PR DESCRIPTION
Following issue https://github.com/try-triplex/triplex/issues/218 Uses [winget-releaser](https://github.com/vedantmgoyal9/winget-releaser) I suggest a `Classic Github Token` with `public_repo` scope is created, following [this link](https://github.com/settings/tokens/new), for the user [triplex-bot](https://github.com/triplex-bot), then the Token can be added to the triplex repo as a secret named `WINGET_ACC_TOKEN`. See below, that user also will have to fork the winget-pkgs repository.

Notes:
> You will need to create a *classic* Personal Access Token (PAT) with `public_repo` scope. New fine-grained PATs aren't supported by the action. Review #172 for information.
> Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under the same account/organization as the project's repository. If you are forking winget-pkgs on a different account (e.g. bot/personal account), you can use the fork-user input to specify the username of the account where the fork is present.